### PR TITLE
Added ape-code. Reasons:

### DIFF
--- a/blah-code.js
+++ b/blah-code.js
@@ -134,8 +134,106 @@
 		return text.join('');
 	};
 
+	/**
+	 *creates Ooks out of a numerical value
+	 *
+	 * @param {Number} The value to ookify
+	 * @return {String} an Ook-representation of the value
+	 * @private
+	 */
+	var ookify = function (value) {
+		var ooks = '';
+		var leftValue = Math.floor(value / 3);
+		if (leftValue > 0) {
+			ooks = ookify(leftValue) + ' ';
+		}
+
+		var rightValue = value % 3;
+
+		if (rightValue === 0) {
+			ooks += 'Ook.';
+		} else if (rightValue === 1) {
+			ooks += 'Ook?';
+		} else if (rightValue === 2) {
+			ooks += 'Ook!';
+		} else {
+			ooks += rightValue + ' said Monkey!';
+		}
+		return ooks;
+	};
+
+	/**
+	 *creates a numerical value out of a set of ooks
+	 *
+	 * @param {String} an Ook-representation of the value
+	 * @return {Number} the numerical value
+	 * @private
+	 */
+	var unookify = function (charTribbles) {
+		var idx = 0;
+		var tribblePattern = /Ook(.)/gi;
+		var match = null;
+		while ((match = tribblePattern.exec(charTribbles)) !== null) {
+			idx *= 3;
+			if (match[1] === '.') {
+				idx += 0;
+			} else if (match[1] === '?') {
+				idx += 1;
+			} else if (match[1] === '!') {
+				idx += 2;
+			} else {
+				console.log('Got Invalid value "' + match[0] + '"');
+			}
+		}
+		return idx;
+	};
+
+	/**
+	 * Encodes human readable text to ape readable code.
+	 * Be aware of the monkeys!
+	 *
+	 * @param       {String} text Normal text.
+	 * @return      {String} ape code
+	 * @public
+	 */
+	var encodeApe = function (text) {
+		var blah = [];
+
+		text.toLowerCase().split('').forEach(function (element) {
+			var position = chars.indexOf(element);
+
+			if (position !== -1) {
+				blah.push(ookify(position).trim());
+			}
+		});
+
+		return blah.join(', ');
+	};
+
+	/**
+	 * Decodes ape readable code to human readable text.
+	 *
+	 * @param       {String} code ape code.
+	 * @return      {String} Human text
+	 * @public
+	 */
+	var decodeApe = function (code) {
+		var charPattern = /(\s*Ook[!?.]\s*)+,?/gi;
+
+		var result = '';
+
+		var characters = null;
+		while ((characters = charPattern.exec(code)) !== null) {
+			var idx = unookify(characters[0]);
+			result += chars[idx];
+		}
+		return result;
+	};
+
 	return {
 		encode: encode,
-		decode: decode
+		encodeApe: encodeApe,
+		decode: decode,
+		decodeApe: decodeApe
 	};
 });

--- a/test.js
+++ b/test.js
@@ -18,3 +18,21 @@ describe('blah-code', function () {
 		expect(blahCode.decode('blah blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah, blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah, blah blah blah blah, blah blah blah blah blah blah blah blah blah, blah blah, blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah, blah blah blah blah blah, blah blah blah blah blah blah')).to.equal('mail@michael-kuehnel.de');
 	});
 });
+
+describe('ape-code', function () {
+	it('should encode text to ape code', function () {
+		expect(blahCode.encodeApe('Hi there!')).to.equal('Ook! Ook!, Ook? Ook. Ook., Ook., Ook! Ook. Ook!, Ook! Ook!, Ook? Ook!, Ook! Ook. Ook., Ook? Ook!, Ook? Ook. Ook? Ook.');
+	});
+
+	it('should decode ape code to text', function () {
+		expect(blahCode.decodeApe('Ook! Ook!, Ook? Ook. Ook., Ook., Ook! Ook. Ook!, Ook! Ook!, Ook? Ook!, Ook! Ook. Ook., Ook? Ook!, Ook? Ook. Ook? Ook.')).to.equal('hi there!');
+	});
+
+	it('should encode email to ape code', function () {
+		expect(blahCode.encodeApe('spamalot@hardcoded.de')).to.equal('Ook! Ook. Ook?, Ook? Ook! Ook?, Ook?, Ook? Ook? Ook?, Ook?, Ook? Ook? Ook., Ook? Ook! Ook., Ook! Ook. Ook!, Ook? Ook. Ook! Ook?, Ook! Ook!, Ook?, Ook! Ook. Ook., Ook? Ook?, Ook? Ook., Ook? Ook! Ook., Ook? Ook?, Ook? Ook!, Ook? Ook?, Ook? Ook. Ook? Ook!, Ook? Ook?, Ook? Ook!');
+	});
+
+	it('should decode ape code to email', function () {
+		expect(blahCode.decodeApe('Ook! Ook. Ook?, Ook? Ook! Ook?, Ook?, Ook? Ook? Ook?, Ook?, Ook? Ook? Ook., Ook? Ook! Ook., Ook! Ook. Ook!, Ook? Ook. Ook! Ook?, Ook! Ook!, Ook?, Ook! Ook. Ook., Ook? Ook?, Ook? Ook., Ook? Ook! Ook., Ook? Ook?, Ook? Ook!, Ook? Ook?, Ook? Ook. Ook? Ook!, Ook? Ook?, Ook? Ook!')).to.equal('spamalot@hardcoded.de');
+	});
+});


### PR DESCRIPTION
- A code should be writable and readable by orang-utans.
- To this end, the code should be simple, easy to remember, and not mention the word "monkey".
- Bananas are good.
